### PR TITLE
changed config to allow to pass a custom ajv instance

### DIFF
--- a/src/configSchema.js
+++ b/src/configSchema.js
@@ -1,6 +1,7 @@
 export default {
   type: 'object',
   properties: {
+    ajv: { type: 'object' },
     actionSchema: { type: 'object' },
     fluxStandardAction: {
       type: 'boolean',

--- a/src/configSchema.test.js
+++ b/src/configSchema.test.js
@@ -1,3 +1,4 @@
+import Ajv from 'ajv';
 import createMiddleware from '.';
 import { catchError } from './testUtils';
 

--- a/src/configSchema.test.js
+++ b/src/configSchema.test.js
@@ -64,4 +64,15 @@ describe('config schema', () => {
       createMiddleware({ storeSchema: 'notobject' });
     }).toThrow();
   });
+
+  it('allows to pass custom ajv instance', () => {
+    expect(() => {
+      const middleware = createMiddleware({
+        ajv: new Ajv({
+          allErrors: true
+        })
+      });
+      expect(middleware).toBeDefined();
+    }).not.toThrow();
+  });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ export default (config = { }) => {
    * Ajv validation object
    * @type {Ajv}
    */
-  const ajv = new Ajv();
+  const ajv = config.ajv || new Ajv();
 
   /**
    * Validate an object against a schema


### PR DESCRIPTION
I have an user case where i have ajv loaded with my custom formats and keywords, so i want to pass this ajv instance into the middleware.
The change does not break the current api because the ajv insntace is optional.